### PR TITLE
Panel styling

### DIFF
--- a/browser/js/common/directives/mix-clip/mix-clip.html
+++ b/browser/js/common/directives/mix-clip/mix-clip.html
@@ -1,7 +1,7 @@
 <div ng-style=" {width: '{{ trackInfo.duration / 3600 * 100}}' + '%', float: 'left', height: '100%'} " ng-drop="true" ng-drop-success="reorder($index, $data, $event, mix)">
   <div id="mix-clip" ng-drag="true" ng-drag-data="trackInfo">
   <!--NP: TODO: replace hardcode 1200 with dynamic custom length -->
-  <span class="">{{ trackInfo.name }}</span>
+  <span>{{ trackInfo.name }}</span>
   {{trackInfo.duration / 3600 * 100}}
   </div>
 </div>

--- a/browser/scss/mix-board/_mix-clip.sass
+++ b/browser/scss/mix-board/_mix-clip.sass
@@ -17,6 +17,7 @@
   text-align: left
   padding: 0 8px
 
+
 //NP: note the below is the tag, not ID
 mix-clip
   border-right: 1px solid black

--- a/browser/scss/mix-board/_mix-editor.sass
+++ b/browser/scss/mix-board/_mix-editor.sass
@@ -10,6 +10,7 @@
   height: 8vh
   background-color: transparent
   border: none
+  overflow: hidden
 
 #lower-panel
   +inner-frame()

--- a/browser/scss/mix-board/mix-board.sass
+++ b/browser/scss/mix-board/mix-board.sass
@@ -40,7 +40,7 @@ mix-header > h3
   top: 60px
   left: 0
   width: 32px
-  height: 32px
+  height: 16px
   background-color: $color-inner-line
   text-align: center
   padding-top: 4px
@@ -52,6 +52,8 @@ mix-header > h3
 #mix-edit-buttons //NP: This must stay below `action-buttons, #mix-edit-buttons` for proper styling
   float: right
   margin: 0 80px
+  height: 0px
+  overflow: show
   div, button
     height: 28px
     position: block
@@ -67,7 +69,7 @@ mix-header > h3
       border: none
       border-bottom: 1px solid white
   #_offset //hacky, temp fix
-    top: -2px
+    top: -3px
 
 .mix-frame
   position: relative


### PR DESCRIPTION
hide overflown tracks (when track length is greater than mix length). And some better positioning.
